### PR TITLE
longer splash screen, changed shortcut, installer config

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,6 +64,9 @@ function delayedIntialization() {
 // Handle Squirrel on Windows startup events
 switch (process.argv[1]) {
 	case '--squirrel-install':
+		autoUpdater.createShortcut(setTimeout(() => {
+			app.quit();
+		}, 3000));
 	case '--squirrel-updated':
 		autoUpdater.createShortcut(() => app.quit());
 		break;
@@ -76,3 +79,4 @@ switch (process.argv[1]) {
 	default:
 		initialize();
 }
+

--- a/script/installer.js
+++ b/script/installer.js
@@ -20,16 +20,19 @@ function getInstallerConfig() {
 	const iconPath = `${config.APP_ICON}.ico`;
 	console.log('Building windows installer...');
 	return Promise.resolve({
-		exe: 'Homey.exe',
-		arch: 'ia32',
 		appDirectory: path.join(config.OUT_PATH, 'Homey-win32-ia32'),
+		authors: config.APP_TEAM,
+		description: config.APP_NAME,
+		exe: `${config.APP_NAME}.exe`,
 		iconUrl: `${config.GITHUB_URL_RAW}/assets/app-icon/${config.APP_NAME}.ico`,
 		loadingGif: config.LOADING_GIF,
 		noMsi: true,
 		outputDirectory: path.join(config.OUT_PATH, 'windows-installer'),
+		productName: config.APP_NAME,
 		remoteReleases: config.GITHUB_URL,
-		setupExe: 'HomeySetup.exe',
+		setupExe: `${config.APP_NAME}Setup-v${config.APP_VERSION}.exe`,
 		setupIcon: iconPath,
+		title: config.APP_NAME,
 		skipUpdateIcon: true,
 	});
 }


### PR DESCRIPTION
 - HomeySetup now contains a version number in the name
 - When launching HomeySetup the splash screen is displayed for longer so the user will not think the setup might have crashed on slower systems.
 - Arch option in the windows installer did not seem to map to anything so I removed it.
 - Added some optional fields to the windows installer.
 - Ensured that the shortcut icon is updated after install is done.